### PR TITLE
Add documentation index pages for reference and tutorials

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,20 +2,23 @@
 
 PromptCrafter is an API backend for managing prompt libraries. It enables developers, prompt engineers, and content creators to store, refine, and evaluate generative AI prompts with features for change tracking, categorization, and result logging.
 
-## What You Can Do with PromptCrafter
+## What you can do with PromptCrafter
 
-### Track and Compare Prompt Outputs
-Log outputs from different models, add notes and scores, and evaluate how prompt revisions affect performance over time.
+### Track and compare prompt outputs
 
-### Organize a Prompt Library
+Log outputs from different models, add notes and scores, and track how prompt revisions affect performance.
+
+### Organize a prompt library
+
 Tag prompts by use case or model and retrieve them quickly using search and filter endpoints. Ideal for managing large collections of reusable prompts.
 
-### Use as a Backend for LLM Tools
+### Use as a backend for LLM tools
+
 Store and retrieve prompt templates dynamically from apps such as chatbot builders, internal AI tools, or writing assistants.
 
-## Get Started
+## Get started
 
-[Quickstart](./quickstart.md): Get the API running and try a basic workflow  
-[Tutorials](./tutorials.md): Step-by-step guides for common tasks  
-[API Reference](./reference.md): Full list of available endpoints  
-[Contact](#): Report issues or request features
+[Quickstart](./quickstart.md): get the API running and try a basic workflow  
+[Tutorials](./tutorials/index.md): step-by-step guides for common tasks  
+[API Reference](./reference/index.md): full list of available endpoints  
+[Contact](#): report issues or request features

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,1 +1,29 @@
-<!-- TODO: Draft content for this topic -->
+# API reference
+
+Available and upcoming reference topics for the PromptCrafter API.
+
+## Prompt endpoints
+
+- [Retrieve all prompts](endpoints/get-prompts.md): `GET /prompts`
+- [Create a new prompt](endpoints/post-prompts.md): `POST /prompts`
+- [Retrieve a prompt by ID](endpoints/get-prompts-id.md): `GET /prompts/:id`
+- [Update a prompt by ID](endpoints/patch-prompts-id.md): `PATCH /prompts/:id`
+- [Delete a prompt by ID](endpoints/delete-prompts-id.md): `DELETE /prompts/:id`
+- [Search prompts](endpoints/get-search.md): `GET /search?q=...` *(not yet written)*
+
+## Log endpoints
+
+- [Retrieve all logs](endpoints/get-logs.md): `GET /logs`
+- [Create a new log](endpoints/post-logs.md): `POST /logs`
+- [Retrieve logs for a specific prompt](endpoints/get-logs-by-prompt.md): `GET /logs?promptId=...` *(not yet written)*
+- [Delete a log by ID](endpoints/delete-logs-id.md): `DELETE /logs/:id`
+
+## Resource definitions
+
+- [Prompt resource](resources/prompt.md)
+- [Log resource](resources/log.md)
+
+## Authentication
+
+- [Sign up](endpoints/post-auth-signup.md): `POST /auth/signup` *(not yet written)*
+- [Log in](endpoints/post-auth-login.md): `POST /auth/login` *(not yet written)*

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,1 +1,9 @@
-<!-- TODO: Draft content for this topic -->
+# Tutorials
+
+Upcoming tutorials for the PromptCrafter API.
+
+- [Create a user](create-user.md)
+- [Create a prompt](create-prompt.md)
+- [Test a prompt](test-prompt.md)
+- [View logs](view-logs.md)
+- [Search prompts](search-prompts.md)


### PR DESCRIPTION
This PR creates two new index pages:

- `reference/index.md`: Lists all reference topics, grouped by endpoint category.
- `tutorials/index.md`: Lists planned current tutorials.

The PR also updates the landing page to link to these index pages using correct relative paths and corrects minor errors of capitalization and wording. All links have been verified against the folder structure to ensure accuracy and navigability.

These additions make the documentation more organized and usable.