### PR TITLE
docs: add reference topics for auth and search endpoints

### DIFF
--- a/docs/reference/endpoints/get-search.md
+++ b/docs/reference/endpoints/get-search.md
@@ -1,1 +1,74 @@
-<!-- TODO: Draft content for this topic -->
+---
+layout: page
+---
+
+# Search prompts
+
+Returns an array of [`prompt`](../resources/prompt.md) objects matching a full-text search query. The query matches against the `title`, `content`, and `tags` fields of each prompt.
+
+## URL
+
+```text
+{server_url}/search?q=your+query+terms
+```
+
+## Method
+
+`GET`
+
+## Parameters
+
+| Parameter name | Type   | Required | Description                                 |
+|----------------|--------|----------|---------------------------------------------|
+| `q`            | string | Yes      | Full-text search query. Matches title, content, and tags. |
+
+## Request headers
+
+| Header name     | Required | Description                                |
+|-----------------|----------|--------------------------------------------|
+| `Authorization` | Yes      | Bearer token used to authenticate the user |
+
+## Request body
+
+None
+
+## Request example
+
+```shell
+curl -H "Authorization: Bearer {your_token}" {server_url}/search?q=marketing+email
+```
+
+## Response body
+
+```json
+[
+  {
+    "_id": "prompt3",
+    "ownerId": "user3",
+    "title": "Newsletter subject lines",
+    "content": "Generate subject lines for a tech product launch email.",
+    "model": "Claude",
+    "tags": ["email", "marketing", "tech"],
+    "createdAt": "2024-02-03T10:00:00Z",
+    "updatedAt": "2024-02-03T10:00:00Z"
+  }
+]
+```
+
+## Return status
+
+| Status code  | Status       | Description                                        |
+|--------------|--------------|----------------------------------------------------|
+| 200          | Success      | Prompts matching the search query returned         |
+| 400          | Bad request  | Missing or malformed query string                 |
+| 401          | Unauthorized | Authentication token missing or invalid           |
+| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+
+## Related
+
+[Get all prompts](get-prompts.md): `GET /prompts`  
+[Retrieve a prompt by ID](get-prompts-id.md): `GET /prompts/:id`  
+[Create a prompt](post-prompts.md): `POST /prompts`  
+[Update a prompt](patch-prompts-id.md): `PATCH /prompts/:id`  
+[Delete a prompt](delete-prompts-id.md): `DELETE /prompts/:id`
+

--- a/docs/reference/endpoints/post-auth-login.md
+++ b/docs/reference/endpoints/post-auth-login.md
@@ -1,1 +1,72 @@
-<!-- TODO: Draft content for this topic -->
+---
+layout: page
+---
+
+# Log in
+
+Authenticates a user and returns a JWT token. All fields are required.
+
+## URL
+
+```text
+{server_url}/auth/login
+```
+
+## Method
+
+`POST`
+
+## Parameters
+
+None
+
+## Request headers
+
+| Header name     | Required | Description                       |
+|-----------------|----------|-----------------------------------|
+| `Content-Type`  | Yes      | Must be set to `application/json` |
+
+## Request body
+
+A JSON object with the user's email and password.
+
+```json
+{
+  "email": "john@example.com",
+  "password": "password123"
+}
+```
+
+## Request example
+
+```shell
+curl -X POST {server_url}/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "john@example.com",
+    "password": "password123"
+  }'
+```
+
+## Response body
+
+A JSON object containing a JWT authentication token.
+
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+## Return status
+
+| Status code  | Status       | Description                                        |
+|--------------|--------------|----------------------------------------------------|
+| 200          | OK           | Authentication successful                          |
+| 400          | Bad request  | Required fields are missing or invalid             |
+| 401          | Unauthorized | Incorrect email or password                        |
+| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+
+## Related
+
+[Sign up](post-auth-signup.md): `POST /auth/signup`

--- a/docs/reference/endpoints/post-auth-signup.md
+++ b/docs/reference/endpoints/post-auth-signup.md
@@ -1,1 +1,74 @@
-<!-- TODO: Draft content for this topic -->
+---
+layout: page
+---
+
+# Sign up
+
+Creates a new user account and returns a JWT authentication token. All fields are required.
+
+## URL
+
+```text
+{server_url}/auth/signup
+```
+
+## Method
+
+`POST`
+
+## Parameters
+
+None
+
+## Request headers
+
+| Header name     | Required | Description                       |
+|-----------------|----------|-----------------------------------|
+| `Content-Type`  | Yes      | Must be set to `application/json` |
+
+## Request body
+
+A JSON object containing user details. All fields are required.
+
+```json
+{
+  "name": "John Doe",
+  "email": "john@example.com",
+  "password": "password123"
+}
+```
+
+## Request example
+
+```shell
+curl -X POST {server_url}/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "John Doe",
+    "email": "john@example.com",
+    "password": "password123"
+  }'
+```
+
+## Response body
+
+A JSON object containing an authentication token.
+
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+## Return status
+
+| Status code  | Status       | Description                                    |
+|--------------|--------------|------------------------------------------------|
+| 201          | Created      | Account created successfully                   |
+| 400          | Bad request  | Required fields are missing or invalid         |
+| 409          | Conflict     | Email already in use                           |
+| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+
+## Related
+
+[Log in](post-auth-login.md): `POST /auth/login`


### PR DESCRIPTION
Adds new reference topics for the following endpoints:
- POST /auth/signup
- POST /auth/login
- GET /search

Each topic includes request and response examples, status codes, and related links. These additions complete the reference coverage for authentication and full-text search in PromptCrafter v1.