### PR TITLE
docs: add tutorials for creating prompts, testing prompts, and viewing logs

### DIFF
--- a/docs/tutorials/create-prompt.md
+++ b/docs/tutorials/create-prompt.md
@@ -1,1 +1,126 @@
-<!-- TODO: Draft content for this topic -->
+---
+layout: page
+title: Create a Prompt
+---
+
+# Create a prompt
+
+This tutorial walks through how to save a prompt to the PromptCrafter API with a POST request. Prompts are the core resource of the API: they store reusable instructions for generative AI models used in applications like ChatGPT, Gemini, and Claude. After your prompt is saved, you can test it, log its outputs, and update it as needed. The tutorial takes about 10-15 minutes to complete.
+
+## Before you start
+
+Before sending the API request, make sure you have:
+
+- A PromptCrafter user account  
+- A bearer token from logging in  
+- Either cURL or Postman installed on your machine  
+
+If you need help creating an account or logging in, see the [Quickstart](../quickstart.md) or the [Create a user](create-user.md) tutorial.
+
+## Write the request body
+
+The request body holds the information that defines your prompt. It includes four fields:
+
+- `title`: A short name to help identify or organize the prompt  
+- `content`: The prompt text sent to the AI model to generate a response  
+- `model`: The name of the AI model to use (for example, `gpt-4` or `dall-e-3`)  
+- `tags`: Optional keywords for grouping the prompt by topic, task, or project. Tags can also help organize prompts into libraries
+
+Here's an example request body:
+
+```json
+{
+  "title": "AI image prompt",
+  "content": "Create a prompt for a surreal mountain landscape painting.",
+  "model": "GPT-4",
+  "tags": ["art", "surreal", "landscape"]
+}
+```
+
+## Make the request
+
+Use the endpoint `https://promptcrafter-production.up.railway.app/prompts` and include the following headers in your request:
+- `Authorization: Bearer {your_token}`
+- `Content-Type: application/json`
+
+### Using cURL
+
+```bash
+curl -X POST https://promptcrafter-production.up.railway.app/prompts \
+  -H "Authorization: Bearer {your_token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "AI image prompt",
+    "content": "Create a prompt for a surreal mountain landscape painting.",
+    "model": "GPT-4",
+    "tags": ["art", "surreal", "landscape"]
+  }'
+```
+
+Replace `{your_token}` with your actual bearer token.
+
+### Using Postman
+
+1. Open Postman
+2. Set method to `POST`
+3. Set URL to:  
+   `https://promptcrafter-production.up.railway.app/prompts`
+4. In the **Authorization** tab:
+   - Type: Bearer Token
+   - Token: `{your_token}`
+5. In the **Headers** tab:
+   - Key: `Content-Type`
+   - Value: `application/json`
+6. In the **Body** tab:
+   - Choose `raw` and `JSON`
+   - Paste the JSON from step 1
+7. Click **Send**
+
+## Check the response
+
+If your request is successful, the server returns a status code `201 Created` and a response body like this:
+
+```json
+{
+  "_id": "prompt2",
+  "ownerId": "user2",
+  "title": "AI image prompt",
+  "content": "Create a prompt for a surreal mountain landscape painting.",
+  "model": "GPT-4",
+  "tags": ["art", "surreal", "landscape"],
+  "createdAt": "2024-02-02T09:00:00Z",
+  "updatedAt": "2024-02-02T09:00:00Z"
+}
+```
+
+> Note: the `_id`, `createdAt`, and `updatedAt` fields are added by the server. Do not include them in the request body.
+
+To confirm that the prompt saved correctly, use the `_id` from the `201 Created` response to retrieve the prompt with a GET request:
+
+```bash
+curl -H "Authorization: Bearer {your_token}" \
+  https://promptcrafter-production.up.railway.app/prompts/{_id}
+```
+
+## What to do if the request doesn't work
+
+The table below lists common errors and how to resolve them.
+
+| Status Code                | What it means                  | What to check                                             |
+|---------------------------|--------------------------------|-----------------------------------------------------------|
+| 400 Bad Request           | The request wasn't valid      | Make sure you included `title`, `content`, and `model` in the request body |
+| 401 Unauthorized          | You're not logged in           | Check that your bearer token is valid and spelled correctly |
+| 403 Forbidden             | Not allowed                    | This action isn't allowed for your account      |
+| 404 Not Found             | The URL doesn't exist | Check the URL for typos                              |
+| 415 Unsupported Media Type | The request format is wrong   | Make sure you set `Content-Type: application/json`        |
+| 500 Internal Server Error | Something went wrong on the server | Try again later or contact support                        |
+
+## Next steps
+
+Now that you can save prompts, learn how to [search prompts](search-prompts.md) or [test prompts](test-prompt.md).
+
+## Related
+
+- [Create a prompt](../references/post-prompts.md)
+- [Retrieve prompts](../references/get-prompts.md)
+- [Prompt resource](../resources/prompt.md)

--- a/docs/tutorials/test-prompt.md
+++ b/docs/tutorials/test-prompt.md
@@ -1,1 +1,139 @@
-<!-- TODO: Draft content for this topic -->
+---
+layout: page
+title: Test a Prompt
+---
+
+# Test a prompt
+
+This tutorial shows how to test a saved prompt by logging its output. The tutorial takes about 5-10 minutes.
+
+## Before you start
+
+Before sending the API request, make sure you have:
+
+- A PromptCrafter user account  
+- A bearer token from logging in  
+- Either cURL or Postman installed  
+
+If you need help creating a user or prompt, see [Create a user](create-user.md) or [Create a prompt](create-a-prompt.md).
+
+## Choose a prompt to test
+
+To get your saved prompts, send a `GET /prompts` request:
+
+```bash
+curl -H "Authorization: Bearer {your_token}" \
+  https://promptcrafter-production.up.railway.app/prompts
+```
+
+Find the `_id` of the prompt you want to test.
+
+## Prepare the log data
+
+The request body for a log includes the prompt ID and the output you want to save. You can also add optional notes and a score (1-10).
+
+- `promptId`: the `_id` of the prompt being tested  
+- `output`: the generated text or image description  
+- `modelUsed`: the model that created the output  
+- `notes`: (optional) your comments on the result  
+- `score`: (optional) your rating of the output  
+
+Example:
+
+```json
+{
+  "promptId": "prompt2",
+  "output": "A dreamlike mountain range under a violet sky.",
+  "notes": "Great visual balance and creativity.",
+  "modelUsed": "DALL·E",
+  "score": 9
+}
+```
+
+## Send the request
+
+Use this endpoint:  
+`https://promptcrafter-production.up.railway.app/logs`
+
+Include these headers:
+
+- `Authorization: Bearer {your_token}`
+- `Content-Type: application/json`
+
+### Using cURL
+
+```bash
+curl -X POST https://promptcrafter-production.up.railway.app/logs \
+  -H "Authorization: Bearer {your_token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "promptId": "prompt2",
+    "output": "A dreamlike mountain range under a violet sky.",
+    "notes": "Great visual balance and creativity.",
+    "modelUsed": "DALL·E",
+    "score": 9
+  }'
+```
+
+### Using Postman
+
+1. Open Postman  
+2. Set method to `POST`  
+3. Set URL to:  
+   `https://promptcrafter-production.up.railway.app/logs`
+4. In the **Authorization** tab:  
+   - Type: Bearer Token  
+   - Token: `{your_token}`  
+5. In the **Headers** tab:  
+   - Key: `Content-Type`  
+   - Value: `application/json`  
+6. In the **Body** tab:  
+   - Choose `raw` and `JSON`  
+   - Paste the JSON from the example above  
+7. Click **Send**
+
+## Check the response
+
+If request is successful, the server returns a `201 Created` response like this:
+
+```json
+{
+  "_id": "log4",
+  "promptId": "prompt2",
+  "output": "A dreamlike mountain range under a violet sky.",
+  "notes": "Great visual balance and creativity.",
+  "modelUsed": "DALL·E",
+  "score": 9,
+  "createdAt": "2024-03-02T12:00:00Z"
+}
+```
+
+To confirm that the log saved correctly, retrieve all logs:
+
+```bash
+curl -H "Authorization: Bearer {your_token}" \
+  https://promptcrafter-production.up.railway.app/logs
+```
+
+## What to do if the request doesn't work
+
+Use this table to check what went wrong:
+
+| Status Code                | What it means                  | What to check                                               |
+|---------------------------|--------------------------------|-------------------------------------------------------------|
+| 400 Bad Request           | The request wasn't valid        | Make sure you included `promptId`, `output`, and `modelUsed` |
+| 401 Unauthorized          | You're not logged in            | Check your bearer token for typos or expiration             |
+| 403 Forbidden             | Not allowed                     | You may not own the prompt you're testing                   |
+| 404 Not Found             | Prompt doesn't exist            | Check that the prompt ID is correct                         |
+| 500 Internal Server Error | Server problem                  | Try again later or contact support                          |
+
+## Next steps
+
+Learn how to [view all logs](view-logs.md) or [search prompts](search-prompts.md) to build on your testing process.
+
+## Related
+
+- [Test a prompt](../reference/endpoints/post-logs.md)  
+- [Retrieve logs](../reference/endpoints/get-logs.md)  
+- [Log resource](../reference/resources/log.md)  
+- [Prompt resource](../reference/resources/prompt.md)

--- a/docs/tutorials/view-logs.md
+++ b/docs/tutorials/view-logs.md
@@ -1,1 +1,96 @@
-<!-- TODO: Draft content for this topic -->
+---
+layout: page
+title: View Logs
+---
+
+# View logs
+
+This tutorial shows how to view your saved logs using the PromptCrafter API. A log records the result of testing a prompt. Each log stores the generated output, the AI model used, and any notes or score you've added. Reviewing logs allows you to analyze and compare results of different tests. The tutorial takes 5-10 minutes to complete.
+
+## Before you start
+
+Before sending the API request, make sure you have:
+
+- A PromptCrafter user account  
+- A bearer token from logging in  
+- At least one log saved using the `POST /logs` endpoint  
+- Either cURL or Postman installed on your machine  
+
+If you need help creating an account or logging in, see the [Quickstart](../quickstart.md) or the [Create a user](create-user.md) tutorial.
+
+## Make the request
+
+Use the endpoint `https://promptcrafter-production.up.railway.app/logs` and include the following request header:
+
+- `Authorization: Bearer {your_token}`
+
+### Using cURL
+
+```bash
+curl -H "Authorization: Bearer {your_token}" \
+  https://promptcrafter-production.up.railway.app/logs
+```
+
+Replace `{your_token}` with your actual bearer token.
+
+### Using Postman
+
+1. Open Postman  
+2. Set method to `GET`  
+3. Set URL to:  
+   `{server_url}/logs`  
+4. In the **Authorization** tab:  
+   - Type: Bearer Token  
+   - Token: `{your_token}`  
+5. Click **Send**
+
+## Check the response
+
+If your request is successful, the server returns a status code `200 OK` and a response body like this:
+
+```json
+[
+  {
+    "_id": "log3",
+    "promptId": "prompt3",
+    "output": "Ready to Upgrade? Discover the Future of Tech.",
+    "notes": "Engaging and clear subject line.",
+    "modelUsed": "Claude",
+    "score": 7,
+    "createdAt": "2024-03-03T13:00:00Z"
+  }
+  {
+    "_id": "log87",
+    "promptId": "prompt34",
+    "output": "I am the ancient apple queen.",
+    "notes": "This is a William Morris line.",
+    "modelUsed": "GPT-4.1",
+    "score": 4,
+    "createdAt": "2025-03-03T13:14:00Z"
+  }
+]
+```
+
+Each object in the array is a log entry. The `promptId` field shows which prompt the log links to.
+
+## What to do if the request doesn't work
+
+The table below lists common errors and how to resolve them.
+
+| Status Code                | What it means                     | What to check                                                 |
+|---------------------------|-----------------------------------|---------------------------------------------------------------|
+| 401 Unauthorized          | You're not logged in              | Make sure your bearer token is included and correct           |
+| 403 Forbidden             | You don't have access             | You may be trying to view logs that belong to another user    |
+| 404 Not Found             | The URL doesn't exist             | Check the URL for typos |
+| 500 Internal Server Error | Something went wrong on the server | Try again later or contact support                            |
+
+## Next steps
+
+Now that you can view logs, learn how to [test a prompt](test-prompt.md) or [delete a log](../reference/endpoints/delete-log.md).
+
+## Related
+
+- [Retrieve logs](../reference/endpoints/get-logs-id.md)  
+- [Test a prompt](../reference/endpoints/post-logs.md)  
+- [Delete a log](../reference/endpoints/delete-logs-id.md)  
+- [Log resource](../reference/resources/log.md)


### PR DESCRIPTION
This commit adds three new tutorials to the documentation:

- `create-prompt.md`: Guides users through creating a new prompt using a POST request
- `test-prompt.md`: Shows how to test a saved prompt and log the output
- `view-logs.md`: Explains how to retrieve and review saved log entries

Each tutorial includes cURL and Postman examples, error handling guidance, and step-by-step instructions.