### PR TITLE
docs: update reference topic error code tables to reflect hosted server behavior

### DIFF
--- a/docs/reference/endpoints/delete-logs-id.md
+++ b/docs/reference/endpoints/delete-logs-id.md
@@ -45,13 +45,14 @@ None
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-|--------------|--------------|----------------------------------------------------|
-| 204          | No content   | Log deleted successfully                           |
-| 401          | Unauthorized | Authentication token missing or invalid            |
-| 403          | Forbidden    | Log does not belong to the authenticated user      |
-| 404          | Not found    | Log with the specified ID was not found            |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 204         | No Content             | Log deleted successfully.                             |
+| 400         | Bad Request            | The request is malformed or the log ID format is invalid. |
+| 401         | Unauthorized           | Authentication token is missing, expired, or invalid. |
+| 403         | Forbidden              | Log does not belong to the authenticated user.        |
+| 404         | Not Found              | No log found with the specified ID.                   |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 

--- a/docs/reference/endpoints/delete-prompts-id.md
+++ b/docs/reference/endpoints/delete-prompts-id.md
@@ -45,13 +45,14 @@ None
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-|--------------|--------------|----------------------------------------------------|
-| 204          | No content   | Prompt deleted successfully                        |
-| 401          | Unauthorized | Authentication token missing or invalid            |
-| 403          | Forbidden    | Prompt does not belong to the authenticated user   |
-| 404          | Not found    | Prompt with the specified ID was not found         |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 204         | No Content             | Prompt deleted successfully.                          |
+| 400         | Bad Request            | The request is malformed or the prompt ID format is invalid. |
+| 401         | Unauthorized           | Authentication token is missing, expired, or invalid. |
+| 403         | Forbidden              | Prompt does not belong to the authenticated user.     |
+| 404         | Not Found              | No prompt found with the specified ID.                |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 

--- a/docs/reference/endpoints/get-logs.md
+++ b/docs/reference/endpoints/get-logs.md
@@ -63,11 +63,12 @@ curl -H "Authorization: Bearer {your_token}" https://promptcrafter-production.up
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-|--------------|--------------|----------------------------------------------------|
-| 200          | Success      | Logs returned successfully                         |
-| 401          | Unauthorized | Authentication token missing or invalid            |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 200         | Success                | Logs returned successfully.                           |
+| 400         | Bad Request            | The request is malformed or contains invalid parameters. |
+| 401         | Unauthorized           | Authentication token is missing, expired, or invalid. |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 

--- a/docs/reference/endpoints/get-prompts-id.md
+++ b/docs/reference/endpoints/get-prompts-id.md
@@ -55,13 +55,14 @@ curl -H "Authorization: Bearer {your_token}" https://promptcrafter-production.up
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-|--------------|--------------|----------------------------------------------------|
-| 200          | Success      | Prompt returned successfully                       |
-| 401          | Unauthorized | Authentication token missing or invalid            |
-| 403          | Forbidden    | Prompt does not belong to the authenticated user   |
-| 404          | Not found    | Prompt with the specified ID was not found         |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 200         | Success                | Prompt returned successfully.                         |
+| 400         | Bad Request            | The request is malformed or the prompt ID format is invalid. |
+| 401         | Unauthorized           | Authentication token is missing, expired, or invalid. |
+| 403         | Forbidden              | Prompt does not belong to the authenticated user.     |
+| 404         | Not Found              | No prompt found with the specified ID.                |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 

--- a/docs/reference/endpoints/get-prompts.md
+++ b/docs/reference/endpoints/get-prompts.md
@@ -65,11 +65,12 @@ curl -H "Authorization: Bearer {your_token}" https://promptcrafter-production.up
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-| ------------ | ------------ | -------------------------------------------------- |
-| 200          | Success      | Prompts returned successfully      |
-| 401          | Unauthorized | Authentication token missing or invalid            |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 200         | Success                | Prompts returned successfully.                        |
+| 400         | Bad Request            | The request is malformed or contains invalid parameters. |
+| 401         | Unauthorized           | Authentication token is missing, expired, or invalid. |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 

--- a/docs/reference/endpoints/get-search.md
+++ b/docs/reference/endpoints/get-search.md
@@ -57,12 +57,12 @@ curl -H "Authorization: Bearer {your_token}" https://promptcrafter-production.up
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-|--------------|--------------|----------------------------------------------------|
-| 200          | Success      | Prompts matching the search query returned         |
-| 400          | Bad request  | Missing or malformed query string                 |
-| 401          | Unauthorized | Authentication token missing or invalid           |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                              |
+|-------------|------------------------|----------------------------------------------------------|
+| 200         | Success                | Prompts matching the search query returned.              |
+| 400         | Bad Request            | Missing or malformed query string.                       |
+| 401         | Unauthorized           | Authentication token is missing, expired, or invalid.    |
+| 500         | Internal Server Error  | An unexpected server error occurred.                     |
 
 ## Related
 

--- a/docs/reference/endpoints/patch-prompts-id.md
+++ b/docs/reference/endpoints/patch-prompts-id.md
@@ -71,14 +71,14 @@ The updated `prompt` object.
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-|--------------|--------------|----------------------------------------------------|
-| 200          | Success      | Prompt updated successfully                        |
-| 400          | Bad request  | Submitted data is invalid                          |
-| 401          | Unauthorized | Authentication token missing or invalid            |
-| 403          | Forbidden    | Prompt does not belong to the authenticated user   |
-| 404          | Not found    | Prompt with the specified ID was not found         |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 200         | Success                | Prompt updated successfully.                          |
+| 400         | Bad Request            | Submitted data is invalid or the prompt ID format is invalid. |
+| 401         | Unauthorized           | Authentication token is missing, expired, or invalid. |
+| 403         | Forbidden              | Prompt does not belong to the authenticated user.     |
+| 404         | Not Found              | No prompt found with the specified ID.                |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 

--- a/docs/reference/endpoints/post-auth-login.md
+++ b/docs/reference/endpoints/post-auth-login.md
@@ -60,12 +60,12 @@ A JSON object containing a JWT authentication token.
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-|--------------|--------------|----------------------------------------------------|
-| 200          | OK           | Authentication successful                          |
-| 400          | Bad request  | Required fields are missing or invalid             |
-| 401          | Unauthorized | Incorrect email or password                        |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 200         | OK                     | Authentication successful.                            |
+| 400         | Bad Request            | Required fields are missing or invalid.               |
+| 401         | Unauthorized           | Incorrect email or password.                          |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 

--- a/docs/reference/endpoints/post-auth-signup.md
+++ b/docs/reference/endpoints/post-auth-signup.md
@@ -62,12 +62,12 @@ A JSON object containing an authentication token.
 
 ## Return status
 
-| Status code  | Status       | Description                                    |
-|--------------|--------------|------------------------------------------------|
-| 201          | Created      | Account created successfully                   |
-| 400          | Bad request  | Required fields are missing or invalid         |
-| 409          | Conflict     | Email already in use                           |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 201         | Created                | Account created successfully.                         |
+| 400         | Bad Request            | Required fields are missing or invalid.               |
+| 409         | Conflict               | Email already in use.                                 |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 

--- a/docs/reference/endpoints/post-logs.md
+++ b/docs/reference/endpoints/post-logs.md
@@ -74,13 +74,13 @@ The newly created `log` object.
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-|--------------|--------------|----------------------------------------------------|
-| 201          | Created      | Log created successfully                           |
-| 400          | Bad request  | Required fields are missing or invalid             |
-| 401          | Unauthorized | Authentication token missing or invalid            |
-| 404          | Not found    | Prompt ID does not exist or is not accessible      |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 201         | Created                | Log created successfully.                             |
+| 400         | Bad Request            | Required fields are missing or invalid.               |
+| 401         | Unauthorized           | Authentication token is missing, expired, or invalid. |
+| 404         | Not Found              | Prompt ID does not exist or is not accessible.        |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 

--- a/docs/reference/endpoints/post-prompts.md
+++ b/docs/reference/endpoints/post-prompts.md
@@ -73,12 +73,12 @@ The newly created `prompt` object.
 
 ## Return status
 
-| Status code  | Status       | Description                                        |
-|--------------|--------------|----------------------------------------------------|
-| 201          | Created      | Prompt created successfully                        |
-| 400          | Bad request  | Required fields are missing or invalid             |
-| 401          | Unauthorized | Authentication token missing or invalid            |
-| ECONNREFUSED | N/A          | Server is offline. Start the service and try again |
+| Status code | Status                 | Description                                           |
+|-------------|------------------------|-------------------------------------------------------|
+| 201         | Created                | Prompt created successfully.                          |
+| 400         | Bad Request            | Required fields are missing or invalid.               |
+| 401         | Unauthorized           | Authentication token is missing, expired, or invalid. |
+| 500         | Internal Server Error  | An unexpected server error occurred.                  |
 
 ## Related
 


### PR DESCRIPTION
- Revised all error code tables in reference topics to remove local-only codes (e.g., ECONNREFUSED) and non-applicable errors.
- Standardized error tables across all reference documentation to match the API’s hosted server response behavior.
- Ensured only valid HTTP status codes and documented API error scenarios are included in each operation’s table.