### PR TITLE
docs: add get-logs-by-prompt reference topic and update related links

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ layout: page
 
 # Quickstart
 
-This Quickstart shows how to create an account, log in, save a prompt, and retrieve it using the PromptCrafter API. Each step includes both cURL and Postman examples.
+This quickstart shows how to create an account, log in, save a prompt, and retrieve it using PromptCrafter API. Each step includes both cURL and Postman examples.
 
 ## 1. Sign up
 
@@ -155,8 +155,8 @@ curl -X GET https://promptcrafter-production.up.railway.app/prompts/prompt2 \
 
 ## 5. Next steps
 
-- [Log a generated output](tutorials/test-prompt.md)  
-- [Retrieve logs for a specific prompt](tutorials/view-logs.md)  
-- [Update a prompt](reference/endpoints/patch-prompts-id.md)  
-- [Search prompts](reference/endpoints/get-search.md)  
-- [Explore all API operations](reference/index.md)
+[Log a generated output](tutorials/test-prompt.md)  
+[Retrieve logs for a specific prompt](tutorials/view-logs.md)  
+[Update a prompt](reference/endpoints/patch-prompts-id.md)  
+[Search prompts](reference/endpoints/get-search.md)  
+[Explore all API operations](reference/index.md)

--- a/docs/reference/endpoints/get-logs-by-prompt.md
+++ b/docs/reference/endpoints/get-logs-by-prompt.md
@@ -1,1 +1,75 @@
-<!-- TODO: Draft content for this topic -->
+---
+layout: page
+---
+
+# Retrieve logs for a specific prompt
+
+Returns an array of [logs](../resources/log.md) recording the outputs of a specified prompt.
+
+## URL
+
+```text
+https://promptcrafter-production.up.railway.app/logs?promptId={prompt_id}
+```
+
+## Method
+
+`GET`
+
+## Parameters
+
+| Parameter name | Type   | Required | Description                      |
+|----------------|--------|----------|----------------------------------|
+| `promptId`     | string | Yes      | The unique ID of the prompt whose logs are to be retrieved |
+
+## Request headers
+
+| Header name     | Required | Description                                |
+|-----------------|----------|--------------------------------------------|
+| `Authorization` | Yes      | Bearer token used to authenticate the user |
+
+## Request body
+
+None
+
+## Request example
+
+```shell
+curl -H "Authorization: Bearer {your_token}" \
+  "https://promptcrafter-production.up.railway.app/logs?promptId=prompt101"
+```
+
+## Response body
+
+A JSON array of `log` objects associated with the specified prompt:
+
+```json
+[
+  {
+    "_id": "log106",
+    "promptId": "prompt101",
+    "output": "The business report finds that revenue increased 12% last quarter, driven by strong online sales. Recommendations include expanding digital marketing and improving supply chain efficiency. No significant risks were found, but leadership should monitor supplier stability. Immediate action is suggested to secure long-term supplier contracts.",
+    "notes": "Summary is clear and actionable. Matches requirements.",
+    "modelUsed": "GPT-4o",
+    "score": 9,
+    "createdAt": "2024-06-20T13:10:00Z"
+  },
+]
+```
+
+## Return status
+
+| Status code  | Status       | Description                                            |
+|--------------|--------------|--------------------------------------------------------|
+| 200          | Success      | Logs returned successfully                             |
+| 400          | Bad request  | `promptId` missing or malformed                        |
+| 401          | Unauthorized | Authentication token missing or invalid               |
+| 403          | Forbidden    | User is not authorized to view logs for this prompt    |
+| 404          | Not found    | No logs found for the specified prompt ID              |
+| 500          | Server error | An unexpected error occurred on the server             |
+
+## Related
+
+[Retrieve all logs](get-logs.md): `GET /logs`  
+[Log a generated output](post-logs.md): `POST /logs`  
+[Delete a log](delete-logs-id.md): `DELETE /logs/:id`  

--- a/docs/reference/endpoints/get-logs.md
+++ b/docs/reference/endpoints/get-logs.md
@@ -41,7 +41,7 @@ curl -H "Authorization: Bearer {your_token}" https://promptcrafter-production.up
 ```json
 [
   {
-    "_id": "log101",
+    "_id": "log106",
     "promptId": "prompt101",
     "output": "The business report finds that revenue increased 12% last quarter, driven by strong online sales. Recommendations include expanding digital marketing and improving supply chain efficiency. No significant risks were found, but leadership should monitor supplier stability. Immediate action is suggested to secure long-term supplier contracts.",
     "notes": "Summary is clear and actionable. Matches requirements.",
@@ -50,7 +50,7 @@ curl -H "Authorization: Bearer {your_token}" https://promptcrafter-production.up
     "createdAt": "2024-06-20T13:10:00Z"
   },
   {
-    "_id": "log103",
+    "_id": "log109",
     "promptId": "prompt103",
     "output": "Dear Ms. Lee, I sincerely apologize for the delay in your order. We take full responsibility for the inconvenience this caused. To make things right, we have expedited your shipment and included a discount on your next purchase. Thank you for your patience.",
     "notes": "Professional and empathetic. Offers compensation as requested.",

--- a/docs/tutorials/create-prompt.md
+++ b/docs/tutorials/create-prompt.md
@@ -5,7 +5,7 @@ title: Create a Prompt
 
 # Tutorial: Save a prompt
 
-This tutorial walks through how to save a prompt to the PromptCrafter API with a POST request. Prompts are the core resource of the API: they store reusable instructions for generative AI models used in applications like ChatGPT, Gemini, and Claude. After your prompt is saved, you can test it, log its outputs, and update it as needed. The tutorial takes about 10-15 minutes to complete.
+This tutorial walks through how to save a prompt to PromptCrafter API with a POST request. Prompts are the core resource of the API: they store reusable instructions for generative AI models used in applications like ChatGPT, Gemini, and Claude. After your prompt is saved, you can test it, log its outputs, and update it as needed. The tutorial takes about 10-15 minutes to complete.
 
 ## Before you start
 
@@ -121,6 +121,6 @@ Now that you can save prompts, learn how to [search prompts](search-prompts.md) 
 
 ## Related
 
-- [Prompt](../resources/prompt.md)
-- [Save a prompt](../references/post-prompts.md): `POST /prompts`
-- [Retrieve prompts](../references/get-prompts.md): `GET /prompts/:id`
+[Prompt](../resources/prompt.md)
+[Save a prompt](../references/post-prompts.md): `POST /prompts`
+[Retrieve prompts](../references/get-prompts.md): `GET /prompts/:id`

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,6 +1,6 @@
 # Tutorials
 
-Upcoming tutorials for the PromptCrafter API.
+Upcoming tutorials for PromptCrafter API.
 
 - [Create a user](create-user.md)
 - [Save a prompt](create-prompt.md)

--- a/docs/tutorials/test-prompt.md
+++ b/docs/tutorials/test-prompt.md
@@ -133,7 +133,7 @@ Learn how to [view all logs](view-logs.md) or [search prompts](search-prompts.md
 
 ## Related
 
-- [Log](../reference/resources/log.md)
-- [Prompt](../reference/resources/prompt.md)
-- [Log a generated output](../reference/endpoints/post-logs.md): `POST /logs`  
-- [Retrieve all logs](../reference/endpoints/get-logs.md): `GET /logs`  
+[Log](../reference/resources/log.md)
+[Prompt](../reference/resources/prompt.md)
+[Log a generated output](../reference/endpoints/post-logs.md): `POST /logs`  
+[Retrieve all logs](../reference/endpoints/get-logs.md): `GET /logs`  

--- a/docs/tutorials/view-logs.md
+++ b/docs/tutorials/view-logs.md
@@ -5,7 +5,7 @@ title: View Logs
 
 # Tutorial: View logs
 
-This tutorial shows how to view your saved logs using the PromptCrafter API. A log records the result of testing a prompt. Each log stores the generated output, the AI model used, and any notes or score you've added. Reviewing logs allows you to analyze and compare results of different tests. The tutorial takes 5-10 minutes to complete.
+This tutorial shows how to view your saved logs using PromptCrafter API. A log records the result of testing a prompt. Each log stores the generated output, the AI model used, and any notes or score you've added. Reviewing logs allows you to analyze and compare results of different tests. The tutorial takes 5-10 minutes to complete.
 
 ## Before you start
 
@@ -90,7 +90,7 @@ Now that you can view logs, learn how to [test a prompt](test-prompt.md) or [del
 
 ## Related
 
-- [Log](../reference/resources/log.md)
-- [Retrieve all logs](../reference/endpoints/get-logs-id.md): `GET /logs`  
-- [Log a generated output](../reference/endpoints/post-logs.md): `POST /logs`  
-- [Delete a log](../reference/endpoints/delete-logs-id.md): `DELETE /logs`  
+[Log](../reference/resources/log.md)
+[Retrieve all logs](../reference/endpoints/get-logs-id.md): `GET /logs`  
+[Log a generated output](../reference/endpoints/post-logs.md): `POST /logs`  
+[Delete a log](../reference/endpoints/delete-logs-id.md): `DELETE /logs`  


### PR DESCRIPTION
- Added new reference topic: GET /logs by prompt ID (get-logs-by-prompt.md)
- Standardized formatting of "Related" links across tutorial pages
- Removed unnecessary "the" before "PromptCrafter API" for consistency