### PR TITLE
docs: correct line breaks in tutorial footer links

### DIFF
--- a/docs/tutorials/create-prompt.md
+++ b/docs/tutorials/create-prompt.md
@@ -136,4 +136,4 @@ Now that you can save prompts, learn how to [search prompts](search-prompts.md) 
 
 [Prompt](../resources/prompt.md)  
 [Save a prompt](../reference/endpoints/post-prompts.md): `POST /prompts`  
-[Retrieve prompts](../reference/endpoints/get-prompts.md): `GET /prompts/:id`
+[Retrieve prompts](../reference/endpoints/get-prompts.md): `GET /prompts/:id`  

--- a/docs/tutorials/search-prompts.md
+++ b/docs/tutorials/search-prompts.md
@@ -110,5 +110,5 @@ Learn how to [save a prompt](create-prompt.md) or [log a generated result](test-
 
 [Prompt](../reference/resources/prompt.md)  
 [Save a prompt](../reference/endpoints/post-prompts.md): `POST /prompts`  
-[Retrieve prompts](../reference/endpoints/get-prompts.md): `GET /prompts/`
-[Retrieve prompts by id](../reference/endpoints/get-prompts-id.md): `GET /prompts/:id`
+[Retrieve prompts](../reference/endpoints/get-prompts.md): `GET /prompts/`  
+[Retrieve prompts by id](../reference/endpoints/get-prompts-id.md): `GET /prompts/:id`  

--- a/docs/tutorials/view-logs.md
+++ b/docs/tutorials/view-logs.md
@@ -95,6 +95,6 @@ Learn how to [log a generated output](test-prompt.md) or [save a prompt](create-
 
 [Log](../reference/resources/log.md)  
 [Retrieve all logs](../reference/endpoints/get-logs.md): `GET /logs`  
-[Retrieve logs for a specific prompt](../reference/endpoints/get-logs-by-prompt.md)
+[Retrieve logs for a specific prompt](../reference/endpoints/get-logs-by-prompt.md)  
 [Log a generated output](../reference/endpoints/post-logs.md): `POST /logs`  
 [Delete a log](../reference/endpoints/delete-logs-id.md): `DELETE /logs`  


### PR DESCRIPTION
- create-prompt.md
- search-prompt.md
- view-logs.md