### PR TITLE
docs: harmonize landing page and OpenAPI intro with Postman Collection

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,24 +4,17 @@ title: PromptCrafter API
 
 # PromptCrafter API
 
-A backend service for storing, organizing, and evaluating generative AI prompts. PromptCrafter is intended for developers, prompt engineers, and others working with generative AI who need to:
+PromptCrafter API is a backend service for easily storing, organizing, and evaluating generative AI prompts. Whether you’re a developer, a prompt engineer, or someone who enjoys experimenting with gen AI, PromptCrafter makes it easy to build a prompt library, track changes and performance, and connect your prompts to your favorite tools.
 
-- Maintain a structured prompt library
-- Track changes and performance over time
-- Use prompt data in external tools or applications
+With this API, you can:
 
-## What the API does
-
-- **Prompt Management**  
-  Save, update, and delete prompts. Group them by project, model, or use case using tags.
-- **Search**  
-  Perform full-text search across all prompts using keywords from the title, content, or tags.
-- **Output Logging**  
-  Record model completions for each prompt, including output text, model used, scores, and notes.
+- **Save and manage prompts:** Store, update, and organize your prompts with titles, content, model specifications, and tags.
+- **Log and score outputs:** Keep a detailed record of prompt outputs from different models, add notes, and score their performance for systematic testing.
+- **Search your library:** Quickly find the exact prompts you need with full-text search across titles, content, and tags.
 
 ## Getting started
 
 - [**Quickstart**](quickstart.md): Set up the API and try a basic workflow.
 - [**Tutorials**](tutorials/index.md): Follow step-by-step guides for common operations.
-- [**API Reference**](reference/index.md): See details for all endpoints, request formats, and response objects.
+- [**API reference**](reference/index.md): See details for all endpoints, request formats, and response objects.
 - [**Contact**](contact.md): Report a bug or request a new feature.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -3,10 +3,12 @@ info:
   title: PromptCrafter API
   version: 1.0.0
   description: |
-    PromptCrafter is a REST API for storing, organizing, and evaluating generative AI prompts.
-    It enables developers and prompt engineers to maintain a structured prompt library, track prompt performance, and integrate prompt management with their own tools.
-    The API provides endpoints for user authentication, prompt CRUD operations, and prompt usage logging.
-    Authentication is required for most endpoints using a Bearer token (JWT) provided at login.
+    PromptCrafter API is a backend service for easily storing, organizing, and evaluating generative AI prompts. Whether you're a developer, a prompt engineer, or someone experimenting with gen AI, PromptCrafter makes it easy to build a prompt library, track changes and performance, and connect your prompts to your favorite tools.
+
+    **Key features:**
+    - **Save and manage prompts:** Organize your prompts with titles, content, model specifications, and tags.
+    - **Log and score outputs:** Keep detailed records of prompt outputs, add notes, and score their performance.
+    - **Search your library:** Use full-text search across all your prompt data.
 
     ## Resources
     - [GitHub repo](https://github.com/Marmelodov/PromptCrafter-API)


### PR DESCRIPTION
- Updated the main docs site landing page (index.md) and the OpenAPI spec info.description to match the introduction used in the Postman Collection.
- All key entry points now use the same product summary and feature list for consistent developer experience.
- Aligned language and tone across documentation assets to ensure a unified, professional presentation for portfolio and end-user use.