### PR TITLE
docs: Revise and expand API tutorials for clarity and usability

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -5,6 +5,7 @@
   - [Save a prompt](tutorials/create-prompt.md)
   - [Log a generated ouput](tutorials/test-prompt.md)
   - [View logs](tutorials/view-logs.md)
+  - [Update a prompt](tutorials/update-prompt.md)
   - [Search prompts](tutorials/search-prompts.md)
 - **API Reference**
   - [Index](reference/index.md)

--- a/docs/tutorials/create-prompt.md
+++ b/docs/tutorials/create-prompt.md
@@ -1,22 +1,19 @@
 # Tutorial: Save a prompt
 
-Save a prompt by sending a `POST /prompts` request. Prompts are the API's core resource, storing reusable instructions for generative AI models like GPT-4o and Claude. Build an organized, searchable library of saved prompts where you can update versions, test outputs across models, log performance with scores and notes, and integrate prompts into tools for automation or experimenting.  
-
-**Things you can do with saved prompts:**  
-- **Automate content creation**: Store a prompt for drafting blog posts in your marketing app, then retrieve it by ID to generate articles in the same style every time without rewriting instructions.  
-- **Test prompt variations**: Tag related prompts (e.g., `sentiment-v1` and `sentiment-v2`) to run side-by-side tests in different AI models, tracking which version produces the most accurate sentiment analysis.  
+Save a prompt by sending a `POST /prompts` request. Prompts are the API's core resource, storing reusable instructions for generative AI models like GPT-4o and Claude. Saving prompts allows you to build an organized, searchable prompt library with which you can:
+- **Automate content creation**: Design prompts for a marketing app that draft blog posts in your brand’s voice, then retrieve them by ID to generate articles in the same style every time without rewriting instructions.  
+- **Build a prompt evaluation suite**: Run systematic experiments to determine the best prompt for a job like sentiment analysis. Tag related prompts (e.g., `sentiment-v1` and `sentiment-v2`) to programmatically test them across AI models and measure which version produces the most accurate outputs.
 - **Collaborate with teams**: Group prompts by topic in a shared library (e.g., "marketing" or "research"), so your team can reuse and update them with version history, eliminating the chaos of prompts buried in emails, docs, or personal notebooks.
 
 This tutorial takes about ten minutes to complete.
 
-## Before you start
+## Prerequisites
 
-Make sure you have:
+To follow this tutorial, you need:
 
-- A PromptCrafter user account and the Bearer token you received when you logged in. For help signing up or logging in, see the [Quickstart](../quickstart.md).
-- cURL or Postman. If you're using Postman, download and import the [PromptCrafter Postman Collection](postman.md).
-
-This tutorial assumes you're familiar with the basics of authentication from the Quickstart. If you haven't already, follow those steps to get your token, which you need for all requests in this tutorial.  
+- **Your JWT token:** All requests require a Bearer token for authentication. If you don't have one, complete the authentication steps in the [Quickstart guide](../quickstart.md) first.
+- **An HTTP client:** This tutorial provides examples for both cURL and Postman.
+    - If you're using Postman, import the [PromptCrafter Postman Collection](postman.md) to follow along.
 
 ## Build the request
 
@@ -50,10 +47,10 @@ The request body contains the information that defines your prompt.
 
 ```json
 {
-  "title": "Historical Explanation for Students",
-  "content": "Explain the significance of the Industrial Revolution to high school students using clear, accessible language. Include at least two key inventions and describe how these changes affected daily life in Europe and America.",
-  "model": "Claude 3 Sonnet",
-  "tags": ["history", "education", "explanation"]
+  "title": "Positive Product Review Writer",
+  "content": "Imagine you are a satisfied customer. Write a friendly, detailed review for a new electric bicycle, mentioning at least three features you enjoyed and describing how it improved your daily commute.",
+  "model": "Grok-3 Beta",
+  "tags": ["review", "product", "writing"]
 }
 ```
 
@@ -66,7 +63,7 @@ To make the cURL commands cleaner, set shell variables for the base URL and your
 
 ```bash
 BASE_URL="https://promptcrafter-production.up.railway.app"
-TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."  # Replace with your actual token
+TOKEN="your-jwt-goes-here" # Replace with your actual token
 ```
 
 Now send the request:
@@ -76,17 +73,17 @@ curl -X POST $BASE_URL/prompts \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "title": "Historical Explanation for Students",
-    "content": "Explain the significance of the Industrial Revolution to high school students using clear, accessible language. Include at least two key inventions and describe how these changes affected daily life in Europe and America.",
-    "model": "Claude 3 Sonnet",
-    "tags": ["history", "education", "explanation"]
+    "title": "Positive Product Review Writer",
+    "content": "Imagine you are a satisfied customer. Write a friendly, detailed review for a new electric bicycle, mentioning at least three features you enjoyed and describing how it improved your daily commute.",
+    "model": "Grok-3 Beta",
+    "tags": ["review", "product", "writing"]
   }'
 ```
 
 After a successful response, save the prompt's `_id` to a variable so you can verify it saved correctly:
 
 ```bash
-PROMPT_ID="prompt104"  # Replace with the _id from your response
+PROMPT_ID="prompt102"  # Replace with the _id from your response
 ```
 
 </details>
@@ -94,27 +91,11 @@ PROMPT_ID="prompt104"  # Replace with the _id from your response
 <details>
 <summary>Postman</summary>
 
-If using the PromptCrafter Postman Collection, select the 'Save a prompt' request, replace the pre-filled example body with the details of your new prompt, and send. The Collection handles authentication automatically by capturing and setting the JWT token in the `{{token}}` variable after login.
+If you've imported the PromptCrafter Postman Collection, sending the request is simple.  
 
-<details>
-<summary>Manual Postman Setup</summary>
-
-1. Navigate to **Send a new API request** and click **New Request**.
-2. Set method to `POST`.
-3. Set URL to:  
-   `https://promptcrafter-production.up.railway.app/prompts`
-4. Click the **Authorization** tab:
-   - In the **Type** dropdown, select `Bearer Token`.
-   - In the **Token** field, enter the bearer token you received after logging in.
-5. Click the **Headers** tab. Add a new header with:
-   - Key: `Content-Type`
-   - Value: `application/json`
-6. In the **Body** tab:
-   - Choose `raw` and `JSON`.
-   - Enter the request body.
-7. Click **Send** to submit the request.
-
-</details>
+1. In the **Prompts** folder, select the **Save a prompt** request.
+2. In the **Body** tab, modify the pre-filled JSON with your prompt's details.
+3. Click **Send**. The collection automatically uses the `{{token}}` variable set during login, so you don't need to configure authorization headers manually.
 
 </details>
 
@@ -126,18 +107,18 @@ If your request is successful, the server returns a status code `201 Created` an
 
 ```json
 {
-  "_id": "prompt104",
-  "ownerId": "user7",
-  "title": "Historical Explanation for Students",
-  "content": "Explain the significance of the Industrial Revolution to high school students using clear, accessible language. Include at least two key inventions and describe how these changes affected daily life in Europe and America.",
-  "model": "Claude 3 Sonnet",
-  "tags": ["history", "education", "explanation"],
-  "createdAt": "2025-06-20T13:03:00Z",
-  "updatedAt": "2025-06-20T13:03:00Z"
+  "_id": "prompt102",
+  "ownerId": "user5",
+  "title": "Positive Product Review Writer",
+  "content": "Imagine you are a satisfied customer. Write a friendly, detailed review for a new electric bicycle, mentioning at least three features you enjoyed and describing how it improved your daily commute.",
+  "model": "Grok-3 Beta",
+  "tags": ["review", "product", "writing"],
+  "createdAt": "2024-06-20T13:01:00Z",
+  "updatedAt": "2024-06-20T13:01:00Z"
 }
 ```
 
-**Note:** the server adds the `_id`, `createdAt`, and `updatedAt` fields. Don't include them in the request body.
+**Note:** the server adds the `_id`, `ownerId`, `createdAt`, and `updatedAt` fields. Don't include them in the request body.
 
 ## Verify the prompt
 
@@ -177,15 +158,10 @@ Here are issues you might encounter when saving prompts and what to do about the
 | **404 Not Found** | `{"error": "Route not found"}` | Incorrect endpoint URL. | Verify the endpoint is `/prompts` with no trailing slash or typos. |
 | **500 Internal Server Error** | `{"error": "An unexpected server error occurred"}` | Server-side processing error. | Retry the request; contact support if the error persists. |
 
-## Next steps
+## Next Steps
 
-- Search your library: [Search prompts](tutorials/search-prompts.md)
-- Test and log outputs: [Log generated outputs](tutorials/test-prompt.md)
-- Update an existing prompt: [Update a prompt](tutorials/update-prompt.md)
-- Explore the full reference: [Prompt resource](reference/resources/prompt.md)
+Now that you've saved your first prompt, you're ready to explore PromtCrafter further.
 
-## Related
-
-[Prompt](reference/resources/prompt.md)  
-[Save a prompt](reference/endpoints/post-prompts.md): `POST /prompts`  
-[Retrieve prompts](reference/endpoints/get-prompts.md): `GET /prompts/:id`
+- Try the [Search prompts tutorial](tutorials/search-prompts.md) to find prompts by keyword.
+- See the [Log a generated output tutorial](tutorials/test-prompt.md) to track prompt performance.
+- For complete details on parameters and endpoints, see the [Prompt resource](reference/resources/prompt.md) and the [`POST /prompts`](reference/endpoints/post-prompts.md) endpoint documentation.

--- a/docs/tutorials/search-prompts.md
+++ b/docs/tutorials/search-prompts.md
@@ -1,109 +1,123 @@
-# Tutorial: Search prompts
+# Tutorial: Search for prompts
 
-Search prompts with a GET /search?q= request. This endpoint performs a full-text, case-insensitive scan of every prompt’s title, content, model, and tags and returns matching prompts ordered by relevance. This tutorial takes about 10 minutes to complete.
+Find prompts in your library by sending a `GET /search` request. This endpoint performs a case-insensitive search across the `title`, `content`, and `tags` of all prompts you own, making it easy to find the exact instructions you need. Systematically searching your library allows you to:
 
-## Before you start
+- **Find and reuse existing work:** A teammate needs to draft an apology email. They can search for `customer apology email` to find and adapt a high-quality prompt someone else has already perfected.
+- **Discover prompts for new tasks:** You're building a new feature that summarizes articles. Search your team's library for `summary` or `tldr` to find relevant prompts to use as a starting point.
+- **Manage prompt versions:** Your team uses version tags like `v1` and `v2`. Search for prompts tagged with `v1` to quickly identify older versions that may need to be updated or archived as part of your maintenance process.
 
-Make sure you have:
+This tutorial takes about five minutes to complete.
 
-- A PromptCrafter user account and the bearer token you received when you logged in. For help signing up or logging in, see the [Quickstart](../quickstart.md).
-- cURL or Postman.  
+## Prerequisites
+
+To follow this tutorial, you need:
+
+- **Your JWT token:** All requests require a Bearer token for authentication. If you don't have one, complete the authentication steps in the [Quickstart guide](../quickstart.md) first.
+- **Saved prompts:** You should have at least one saved prompt in your library. If you need to create one, complete the [Save a prompt tutorial](create-prompt.md).
+- **An HTTP client:** This tutorial provides examples for both cURL and Postman.
+    - If you're using Postman, import the [PromptCrafter Postman Collection](postman.md) to follow along easily.
 
 ## Build the request
 
-To search your prompts, send a `GET` request to `/search` and include your search terms in the `q` query parameter.
-
-### Endpoint format
+To search for prompts, send a `GET` request to the following endpoint:
 
 ```text
-GET https://promptcrafter-production.up.railway.app/search?q={search_terms}
+https://promptcrafter-production.up.railway.app/search
 ```
 
-- Replace `{search_terms}` with one or more words.  
-- Separate multiple words with either a plus sign (`+`) or `%20` (URL-encoded space).
+The request includes an authorization header and a query parameter with your search term.
 
-**Examples**
+### Headers
 
-| Search goal                              | URL example                                                          |
-|------------------------------------------|-----------------------------------------------------------------------|
-| Single word (“marketing”)                | `/search?q=marketing`                                                |
-| Multi-word phrase (“email subject”)      | `/search?q=email+subject` or `/search?q=email%20subject`             |
-| Prompts containing both “cold” and “email” | `/search?q=cold+email`                                               |
+Add the following header to your request:
 
-### Required query parameter
+- `Authorization: Bearer {your_token}` authenticates you as the user. Replace `{your_token}` with the bearer token you received after logging in.
 
-| Parameter | Where  | Required | Description                                      |
-|-----------|--------|----------|--------------------------------------------------|
-| `q`       | Query  | Yes      | Words or phrase to search for (full-text, case-insensitive) |
+### Query parameters
 
-### Required header
+The request requires a single query parameter to specify what you're looking for.
 
-- `Authorization: Bearer {your_token}`
+| Parameter | Type   | Required | Description                                                            |
+|-----------|--------|----------|------------------------------------------------------------------------|
+| `q`       | string | Yes      | The search term to match against prompt titles, content, and tags.     |
+
+The search is case-insensitive and matches partial words; for example, a query for "email" finds prompts containing "emails" or "emailing." To search for multiple words, separate them with `+` or `%20` (e.g., `?q=product+review`). Multiple words are treated as separate search terms that can appear anywhere in the prompt's searchable fields.
 
 ## Send the request
 
-### Using Postman
+<details>
+<summary>cURL</summary>
 
-1. Navigate to **Send a new API request** and click **New Request**.
-2. Set method to `GET`
-3. Set URL to:  
-   `https://promptcrafter-production.up.railway.app/search?q=email+subject`
-4. Click the **Authorization** tab:
-   - In the **Type** dropdown, select `Bearer Token`.
-   - In the **Token** field, enter the bearer token you received after logging in.
-5. Click **Send** to submit the request.
-
-### Using cURL
+To make the cURL commands cleaner, set shell variables for the base URL and your token.
 
 ```bash
-curl -H "Authorization: Bearer {your_token}" \
-     "https://promptcrafter-production.up.railway.app/search?q=email+subject"
+BASE_URL="https://promptcrafter-production.up.railway.app"
+TOKEN="your-jwt-goes-here" # Replace with your actual token
 ```
+
+Now send a request with your search term in the `q` query parameter.
+
+```bash
+# Search for prompts related to a single term ("python")
+curl -X GET "$BASE_URL/search?q=python" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Search for prompts related to multiple terms ("product marketing")
+curl -X GET "$BASE_URL/search?q=product+marketing" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+</details>
+
+<details>
+<summary>Postman</summary>
+
+If you've imported the PromptCrafter Postman Collection, sending the request is simple. The collection automatically handles authentication for you.
+
+1. In the **Search** folder, select the **Search prompts** request.
+2. In the **Params** tab, find the key `q`. In the **VALUE** column next to it, enter your search term (e.g., `python`).
+3. Click **Send**. The collection automatically uses the `{{token}}` variable set during login, so you don't need to configure authorization headers manually.
+
+</details>
 
 ## Response
 
-A successful search returns **200 OK** and a JSON array of prompt objects:
+A successful request returns a `200 OK` status and a JSON array of prompt objects that match your query, sorted by relevance.
 
 ```json
 [
   {
-    "_id": "prompt112",
-    "title": "Email Subject Line",
-    "content": "Write a catchy subject line for a product-launch email.",
-    "model": "GPT-4o",
-    "tags": ["marketing", "email"],
-    "createdAt": "2025-06-10T14:23:00Z"
-  },
-  {
-    "_id": "prompt87",
-    "title": "Cold-email opener",
-    "content": "Draft the first line of a cold email that grabs attention.",
-    "model": "Claude 3 Sonnet",
-    "tags": ["sales", "email"],
-    "createdAt": "2025-05-22T09:11:00Z"
+    "_id": "prompt314",
+    "ownerId": "user980",
+    "title": "Python Function Generator",
+    "content": "Write a Python function that takes a list of dictionaries representing users and returns a list of emails.",
+    "model": "GPT-4.1",
+    "tags": ["python", "code-generation", "developer"],
+    "createdAt": "2025-06-20T13:22:12.000Z",
+    "updatedAt": "2025-06-20T13:22:12.000Z"
   }
 ]
 ```
 
-Prompts appear in order of relevance: the first item matches the most words in `q`.
+**Understanding results ordering:** Prompts appear in order of relevance. The search algorithm considers matches in titles more relevant than matches in content or tags, so prompts with titles that match your query will appear higher in the results.
+
+If no prompts match your search term, the API returns a `200 OK` status with an empty array `[]`.
 
 ## What to do if the request doesn't work
 
-Here are error codes you might encounter, what each means, and what you can do to fix them.
+Here are issues you might encounter when searching for prompts and how to resolve them.
 
-| Status | Example response body | Meaning | How to fix |
-|--------|----------------------|---------|------------|
-| **400 Bad Request** | `{ "message": "q parameter is required" }` | The query string is missing or empty. | Add `?q={search_terms}` to the URL. |
-| **401 Unauthorized** | `{ "message": "Invalid or missing bearer token" }` | Authentication failed. | Add `Authorization: Bearer {your_token}` and confirm the token hasn’t expired. |
-| **500 Internal Server Error** | `{ "message": "Unexpected server error" }` | The server encountered an error while processing the request. | Retry later; if the error persists, contact support. |
+| Status | Example response | Cause | Solution |
+|--------|------------------|--------|----------|
+| **400 Bad Request** | `{"error": "Missing or malformed query string"}` | The `q` query parameter is missing from the URL. | Add `?q=` followed by your search term to the end of the request URL. |
+| **401 Unauthorized** | `{"error": "Authentication token is missing"}` | The `Authorization` header is missing. | Include `Authorization: Bearer {your_token}` in your request headers with a valid token. |
+| **401 Unauthorized** | `{"error": "Authentication token is expired or invalid"}` | The bearer token is expired or malformed. | Log in again to obtain a new token and update your request. |
+| **500 Internal Server Error** | `{"error": "An unexpected server error occurred"}` | An error occurred on the server. | Retry the request after a short wait. If the error persists, contact support. |
 
-## Next steps
+## Next Steps
 
-Learn how to [save a prompt](tutorials/create-prompt.md) or [log a generated result](tutorials/test-prompt.md).
+Now that you can find prompts in your library, you are ready to use them to build and test solutions.
 
-## Related
-
-[Prompt](reference/resources/prompt.md)  
-[Save a prompt](reference/endpoints/post-prompts.md): `POST /prompts`  
-[Retrieve prompts](reference/endpoints/get-prompts.md): `GET /prompts/`  
-[Retrieve prompts by id](reference/endpoints/get-prompts-id.md): `GET /prompts/:id`  
+- Try the [Log a generated output tutorial](tutorials/test-prompt.md) to test a prompt you found.
+- Learn how to [update a prompt](tutorials/update-prompt.md) with new content or tags.
+- For complete details on parameters and endpoints, see the [Prompt resource](reference/resources/prompt.md) and the [`GET /search`](reference/endpoints/get-search.md) endpoint documentation.

--- a/docs/tutorials/test-prompt.md
+++ b/docs/tutorials/test-prompt.md
@@ -1,28 +1,25 @@
 # Tutorial: Log a generated output
 
-Record the output of a prompt test with a `POST /logs` request. A log contains the model’s output, the prompt ID, optional notes, and a quality score, giving you a permanent history of each test. After logging an output you can review it and compare the results of different tests. This tutorial takes about 10 minutes to complete.
+Log a generated output by sending a `POST /logs` request. Logs are the API's primary resource for evaluating prompt performance, linking a specific prompt (`promptId`) to a model's generated `output` along with contextual `notes` and a `score`. Systematically logging outputs enables you to:
 
-## Before you start
+- **Refine a customer support chatbot:** Log chatbot responses to common user queries, then score them for accuracy and helpfulness to identify which prompts need improvement.
+- **A/B test marketing copy:** Test two versions of a prompt that generates e-commerce product descriptions. Log the outputs from each, score them based on engagement metrics, and use the data to choose the better-performing prompt.
+- **Create a regression test suite:** After updating a critical prompt, run it against a set of test cases and log the outputs. Compare new logs to previous ones to ensure the prompt's performance hasn't degraded.
 
-Make sure you have:
+This tutorial takes about ten minutes to complete.
 
-- A PromptCrafter user account and the bearer token you received when you logged in. For help signing up or logging in, see the [Quickstart](../quickstart.md).
-- cURL or Postman.  
+## Prerequisites
 
-## Choose a prompt to test
+To follow this tutorial, you need:
 
-To retrieve your saved prompts, send a `GET /prompts` request:
-
-```bash
-curl -H "Authorization: Bearer {your_token}" \
-  https://promptcrafter-production.up.railway.app/prompts
-```
-
-Find the `_id` of the prompt you want to test.
+*   **Your JWT token:** All requests require a Bearer token for authentication. If you don't have one, complete the authentication steps in the [Quickstart](../quickstart.md) first.
+*   **A saved prompt's ID:** You need the `_id` of a prompt you've already saved. If you don't have one, complete the [Save a prompt tutorial](create-prompt.md).
+*   **An HTTP client:** This tutorial provides examples for both cURL and Postman.
+    *   If you're using Postman, import the [PromptCrafter Postman Collection](postman.md) to follow along easily.
 
 ## Build the request
 
-To log a generated result, send a POST request to the following endpoint:
+To log a new output, send a `POST` request to the following endpoint:
 
 ```text
 https://promptcrafter-production.up.railway.app/logs
@@ -34,105 +31,142 @@ The request includes two headers and a JSON-formatted request body.
 
 Add the following headers to your request:
 
-- `Authorization: Bearer {your_token}` authenticates you as the user. Replace `{your_token}` with the bearer token you received after logging in.  
+- `Authorization: Bearer {your_token}` authenticates you as the user. Replace `{your_token}` with the bearer token you received after logging in.
 - `Content-Type: application/json` tells the server to expect a JSON object in the request body.
 
 ### Request body
 
-The request body contains the data for the output you are logging.
+The request body contains the data from your prompt test.
 
-| Field       | Type            | Required | Description                                                                                 |
-|-------------|-----------------|----------|---------------------------------------------------------------------------------------------|
-| `promptId`  | string          | Yes      | ID of the prompt that generated this output.                                                |
-| `output`    | string          | Yes      | Text returned by the AI model.                                                              |
-| `modelUsed`     | string          | Yes      | Name of the model that generated the output (for example `gpt-4o`, `Claude 3 Sonnet`).      |
-| `notes`     | string          | No       | Optional analyst comments or context for later review.                                      |
-| `score`     | integer         | No       | Optional quality rating (for example 0–10) |
+| Field       | Type    | Required | Description                                                                    |
+|-------------|---------|----------|--------------------------------------------------------------------------------|
+| `promptId`  | string  | Yes      | The unique `_id` of the prompt that generated this output.                       |
+| `output`    | string  | Yes      | The text returned by the AI model.                                             |
+| `modelUsed` | string  | Yes      | Name of the model that generated the output (e.g., `gpt-4o`, `Claude 3 Sonnet`). |
+| `notes`     | string  | No       | Optional comments or context for later review.                                 |
+| `score`     | integer | No       | Optional quality rating (e.g., on a scale of 0–10).                           |
 
-Example request body:
+**Example request body:**
 
 ```json
 {
   "promptId": "prompt104",
   "output": "The Industrial Revolution transformed how people lived and worked by introducing inventions like the steam engine and the spinning jenny. These technologies allowed factories to produce goods faster, making everyday items cheaper and more accessible for families throughout Europe and America.",
-  "notes": "Clear, accessible explanation for students.",
   "modelUsed": "Claude 3 Sonnet",
+  "notes": "Clear, accessible explanation for students. Good tone.",
   "score": 8
 }
 ```
 
 ## Send the request
 
-### Using Postman
+<details>
+<summary>cURL</summary>
 
-1. Navigate to **Send a new API request** and click **New Request**.
-2. Set method to `POST`
-3. Set URL to:  
-   `https://promptcrafter-production.up.railway.app/logs`
-4. Click the **Authorization** tab:
-   - In the **Type** dropdown, select `Bearer Token`.
-   - In the **Token** field, enter the bearer token you received after logging in.
-5. Click the **Headers** tab. Add a new header with:
-   - Key: `Content-Type`
-   - Value: `application/json`
-6. In the **Body** tab:
-   - Choose `raw` and `JSON`
-   - Enter the request body
-7. Click **Send** to submit the request.
-
-### Using cURL
+To make the cURL commands cleaner, set shell variables for the base URL, your token, and the prompt ID. This avoids repeating them in every request.
 
 ```bash
-curl -X POST https://promptcrafter-production.up.railway.app/logs \
-  -H "Authorization: Bearer {your_token}" \
+BASE_URL="https://promptcrafter-production.up.railway.app"
+TOKEN="your-jwt-goes-here" # Replace with your actual token
+PROMPT_ID="prompt104" # Replace with the ID of your prompt
+```
+
+Now send the request:
+
+```bash
+curl -X POST $BASE_URL/logs \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "promptId": "prompt104",
+    "promptId": "'"$PROMPT_ID"'",
     "output": "The Industrial Revolution transformed how people lived and worked by introducing inventions like the steam engine and the spinning jenny. These technologies allowed factories to produce goods faster, making everyday items cheaper and more accessible for families throughout Europe and America.",
-    "notes": "Clear, accessible explanation for students.",
     "modelUsed": "Claude 3 Sonnet",
+    "notes": "Clear, accessible explanation for students. Good tone.",
     "score": 8
   }'
 ```
 
+After a successful response, you can save the log's `_id` to a variable for future use:
+
+```bash
+LOG_ID="log104"  # Replace with the _id from your response
+```
+
+</details>
+
+<details>
+<summary>Postman</summary>
+
+If you have imported the PromptCrafter Postman Collection, sending the request is simple. The collection is pre-configured to handle authentication for you.
+
+1.  In the **Logs** folder, select the **Log a generated output** request.
+2.  In the **Body** tab, modify the pre-filled JSON with your test data, ensuring you replace the example `promptId` with the ID of a prompt you own.
+3.  Click **Send**. The collection automatically uses the `{{token}}` variable set during login, so you don't need to configure authorization headers manually.
+
+</details>
+
+A successful request returns a `201 Created` status and the full log object, including its unique server-generated `_id`.
+
 ## Response
 
-If request is successful, the server returns a `201 Created` response like this:
+If your request is successful, the server returns a `201 Created` status code and a response body that looks like this:
 
 ```json
 {
   "_id": "log104",
   "promptId": "prompt104",
   "output": "The Industrial Revolution transformed how people lived and worked by introducing inventions like the steam engine and the spinning jenny. These technologies allowed factories to produce goods faster, making everyday items cheaper and more accessible for families throughout Europe and America.",
-  "notes": "Clear, accessible explanation for students.",
   "modelUsed": "Claude 3 Sonnet",
+  "notes": "Clear, accessible explanation for students. Good tone.",
   "score": 8,
   "createdAt": "2024-06-20T13:13:00Z"
 }
 ```
 
-Note: the server adds the `_id`, `createdAt`, and `updatedAt` fields. Don't include them in the request body.
+**Note:** The server adds the `_id` and `createdAt` fields. Do not include them in your request body.
+
+## Verify the log
+
+To confirm your log was saved successfully, send a `GET` request to retrieve all logs for that prompt using the `promptId`.
+
+<details>
+<summary>cURL</summary>
+
+Use the variables you set earlier.
+
+```bash
+curl -X GET "$BASE_URL/logs?promptId=$PROMPT_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+</details>
+
+<details>
+<summary>Postman</summary>
+
+Use the **Retrieve logs by prompt** request in the `Logs` folder. Ensure the `promptId` in the query parameters matches your prompt's `_id`, then click **Send**.
+
+</details>
+
+Expect a `200 OK` status with a JSON array containing the log object you just created. This confirms your test result is stored and ready for analysis.
 
 ## What to do if the request doesn't work
 
-Here are error codes you might encounter, what each means, and what you can do to fix them.
+Here are issues you might encounter when logging outputs and how to resolve them.
 
-| Status | Example response body | Meaning | How to fix |
-|--------|----------------------|---------|------------|
-| **400 Bad Request** | `{ "message": "promptId, output, and model are required" }` | One or more required fields are missing or the JSON is malformed. | Include `promptId`, `output`, and `model`, and make sure the body is valid JSON. |
-| **401 Unauthorized** | `{ "message": "Invalid or missing bearer token" }` | Authentication failed. | Add `Authorization: Bearer {your_token}` and confirm the token hasn’t expired. |
-| **403 Forbidden** | `{ "message": "You do not own this prompt" }` | You authenticated, but you lack permission to log against this prompt. | Verify that the prompt belongs to your account. |
-| **404 Not Found** | `{ "message": "Prompt not found" }` | The server can’t find the prompt referenced by `promptId`. | Check that the `promptId` is correct and still exists. |
-| **415 Unsupported Media Type** | `{ "message": "Content-Type must be application/json" }` | The server couldn’t parse the body because the header is wrong or absent. | Add `Content-Type: application/json` to the request headers. |
-| **500 Internal Server Error** | `{ "message": "Unexpected server error" }` | The server encountered an error while processing the request. | Retry later; if the error persists, contact support. |
+| Status | Example response | Cause | Solution |
+|--------|------------------|--------|----------|
+| **400 Bad Request** | `{"error": "Required fields are missing or invalid"}` | Missing required fields (`promptId`, `output`, `modelUsed`) or invalid JSON syntax. | Verify all required fields are present and that the JSON is properly formatted. |
+| **401 Unauthorized** | `{"error": "Authentication token is missing"}` | The `Authorization` header is missing. | Include `Authorization: Bearer {your_token}` in your request headers with a valid token. |
+| **401 Unauthorized** | `{"error": "Authentication token is expired or invalid"}` | The bearer token is expired or malformed. | Log in again to obtain a new token and update your request. |
+| **404 Not Found** | `{"error": "Prompt ID does not exist or is not accessible"}` | The `promptId` does not exist or belongs to another user. | Check that the `promptId` is correct and corresponds to a prompt you own. |
+| **415 Unsupported Media Type** | `{"error": "Content-Type must be application/json"}` | The `Content-Type` header is missing or incorrect. | Add `Content-Type: application/json` to your request headers. |
+| **500 Internal Server Error** | `{"error": "An unexpected server error occurred"}` | An error occurred on the server. | Retry the request after a short wait. If the error persists, contact support. |
 
-## Next steps
+## Next Steps
 
-Learn how to [view all logs](tutorials/view-logs.md) or [search prompts](tutorials/search-prompts.md).
+Now that you can log prompt outputs, you`re ready to build a data-driven evaluation process.
 
-## Related
-
-[Log](reference/resources/log.md)  
-[Prompt](reference/resources/prompt.md)  
-[Log a generated output](reference/endpoints/post-logs.md): `POST /logs`  
-[Retrieve all logs](reference/endpoints/get-logs.md): `GET /logs`  
+- Try the [Search prompts tutorial](tutorials/search-prompts.md) to find prompts by keyword.  
+- Learn how to [Update a prompt](tutorials/update-prompt.md) based on the insights from your logged tests.  
+- For complete details on endpoints and para, see the [Log resource](reference/resources/log.md) and the [`POST /logs`](reference/endpoints/post-logs.md) endpoint documentation.

--- a/docs/tutorials/update-prompt.md
+++ b/docs/tutorials/update-prompt.md
@@ -1,0 +1,156 @@
+# Tutorial: Update a prompt
+
+Update an existing prompt by sending a `PATCH /prompts/{promptId}` request. This method allows you to modify specific fields of a prompt—like its `title`, `content`, `model`, or `tags`—without rewriting the entire resource. Keeping your prompts current is essential for iterative development and library maintenance. You can:
+
+- **Refine prompt instructions:** After testing, you might find a small change to a prompt's `content` significantly improves output quality. You can update the text while leaving the title and tags unchanged.
+- **Upgrade to a new model:** When a more advanced AI model is released, update the `model` field on your best prompts to take advantage of the latest technology.
+- **Reorganize your library:** As projects evolve, change a prompt's `tags` to better reflect its current use case (e.g., changing a tag from `draft` to `production-ready`).
+
+This tutorial takes about ten minutes to complete.
+
+## Prerequisites
+
+To follow this tutorial, you need:
+
+- **Your JWT token:** All requests require a Bearer token for authentication. If you don't have one, complete the authentication steps in the [Quickstart guide](../quickstart.md) first.
+- **A saved prompt's ID:** You need the `_id` of a prompt you've already saved. If you don't have one, complete the [Save a prompt tutorial](create-prompt.md) first.
+- **An HTTP client:** This tutorial provides examples for both cURL and Postman.
+    - If you're using Postman, import the [PromptCrafter Postman Collection](postman.md) to follow along.
+
+## Build the request
+
+To update a prompt, send a `PATCH` request to the following endpoint, replacing `{promptId}` with the ID of the prompt you want to modify:
+
+```text
+https://promptcrafter-production.up.railway.app/prompts/{promptId}
+```
+
+The request includes headers, a path parameter, and a JSON-formatted request body with only the fields you want to change.
+
+### Headers
+
+Add the following headers to your request:
+
+- `Authorization: Bearer {your_token}` authenticates you as the user. Replace `{your_token}` with the bearer token you received after logging in.
+- `Content-Type: application/json` tells the server to expect a JSON object in the request body.
+
+### Request body
+
+The request body should only contain the fields you want to update. All fields are optional. Any fields you omit remain unchanged.
+
+| Field    | Type             | Required | Description                                                            |
+|----------|------------------|----------|------------------------------------------------------------------------|
+| `title`  | string           | No       | A new label to help identify or sort the prompt.                       |
+| `content`| string           | No       | The revised text to be sent to the AI model.                           |
+| `model`  | string           | No       | The name of a different model (e.g., `gpt-4o`, `Claude 3 Sonnet`).     |
+| `tags`   | array&lt;string&gt;  | No       | A new set of keywords for organization.  |
+
+**Example request body (updating the model and tags):**
+
+```json
+{
+  "model": "GPT-4o",
+  "tags": ["review", "product", "writing", "e-commerce"]
+}
+```
+
+## Send the request
+
+<details>
+<summary>cURL</summary>
+
+To make the cURL commands cleaner, set shell variables for the base URL, your token, and the prompt's ID.
+
+```bash
+BASE_URL="https://promptcrafter-production.up.railway.app"
+TOKEN="your-jwt-goes-here" # Replace with your actual token
+PROMPT_ID="your-prompt-id-here" # Replace with the ID of the prompt you want to update
+```
+
+Now send the `PATCH` request. This example updates the `model` and `tags` for the specified prompt.
+
+```bash
+curl -X PATCH "$BASE_URL/prompts/$PROMPT_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "GPT-4o",
+    "tags": ["review", "product", "writing", "e-commerce"]
+  }'
+```
+
+</details>
+
+<details>
+<summary>Postman</summary>
+
+If you've imported the PromptCrafter Postman Collection, sending the request is simple.  
+
+1. In the **Prompts** folder, select the **Update a prompt** request.
+2. In the **Variables** tab, paste the `_id` of the prompt you want to update into the `CURRENT VALUE` field for the `promptId` variable. The request URL automatically uses this value.
+3. In the **Body** tab of the request, edit the JSON to include only the fields you wish to change.
+4. Click **Send**. The collection automatically uses the `{{token}}` variable set during login, so you don't need to configure authorization headers manually.
+
+</details>
+
+## Response
+
+A successful request returns a `200 OK` status and the full, updated prompt object. Notice that the `updatedAt` timestamp has changed to reflect when the modification occurred.
+
+```json
+{
+  "_id": "prompt102",
+  "ownerId": "user5",
+  "title": "Positive Product Review Writer",
+  "content": "Imagine you are a satisfied customer. Write a friendly, detailed review for a new electric bicycle, mentioning at least three features you enjoyed and describing how it improved your daily commute.",
+  "model": "GPT-4o",
+  "tags": ["review", "product", "writing", "e-commerce"],
+  "createdAt": "2024-06-20T13:01:00Z",
+  "updatedAt": "2025-07-21T10:30:00Z"
+}
+```
+
+## Verify the update
+
+To confirm your prompt was updated successfully, send a `GET` request to retrieve the prompt using its `_id`.
+
+<details>
+<summary>cURL</summary>
+
+Use the variables you set earlier.
+
+```bash
+curl -X GET "$BASE_URL/prompts/$PROMPT_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+</details>
+
+<details>
+<summary>Postman</summary>
+
+Use the **Retrieve a prompt by ID** request in the `Prompts` folder. The `promptId` variable should already be set from the previous step. Click **Send** and inspect the response to confirm your changes were applied.
+
+</details>
+
+The response shows the fields with their new values, confirming the update was successful.
+
+## What to do if the request doesn't work
+
+Here are issues you might encounter when updating prompts and how to resolve them.
+
+| Status | Example response | Cause | Solution |
+|--------|------------------|--------|----------|
+| **400 Bad Request** | `{"error": "Submitted data is invalid."}` | The data in the request body is malformed (e.g., `tags` is not an array) or violates validation rules. | Check that your JSON is valid and that all field values meet the required format. |
+| **401 Unauthorized** | `{"error": "Authentication token is expired or invalid."}` | The bearer token is missing, malformed, or has expired. | Include a valid `Authorization: Bearer {your_token}` header. If needed, log in again to get a new token. |
+| **403 Forbidden** | `{"error": "Prompt does not belong to the authenticated user."}` | You are trying to update a prompt that you do not own. | Verify you are using the correct `promptId` for a prompt associated with your account. |
+| **404 Not Found** | `{"error": "No prompt found with the specified ID."}` | The `promptId` in the URL does not exist in the database. | Double-check that the `promptId` is correct and has not been deleted. |
+| **500 Internal Server Error** | `{"error": "An unexpected server error occurred"}` | An error occurred on the server. | Retry the request after a short wait. If the error persists, contact support. |
+
+## Next Steps
+
+Now that you can modify your prompts, you can manage your library and iterate on your work.
+
+- Try the [Log a generated output tutorial](tutorials/test-prompt.md) to test your updated prompt and see if its performance has improved.
+- Learn how to [View logs](tutorials/view-logs.md) to compare test results before and after your update.
+- For complete details on parameters and endpoints, see the [prompt resource](reference/resources/prompt.md) and the [`PATCH /prompts/{promptId}`](reference/endpoints/patch-prompts-id.md) endpoint documentation.

--- a/docs/tutorials/view-logs.md
+++ b/docs/tutorials/view-logs.md
@@ -1,95 +1,139 @@
 # Tutorial: View logs
 
-Retrieve prompt test logs with a `GET /logs` request. Each log stores the model’s output, the prompt ID, the model name, optional notes, and a score. Reviewing logs lets you analyze and compare results across tests. This tutorial takes about 5 minutes to complete.
+Retrieve prompt test logs by sending a `GET /logs` request. Each log records a model's `output`, linking it to the `promptId` that produced it. Reviewing logs allows you to analyze and compare results across tests, identify performance patterns, and systematically improve your prompts. You can:
 
-## Before you start
+- **Analyze chatbot performance:** Retrieve logs for a specific `promptId` used by a chatbot to see a complete history of its responses to users, then analyze the scores and notes to find areas for improvement.
+- **Compare A/B test results:** Fetch logs for two different prompt versions (e.g., `prompt-A` and `prompt-B`) to compare their average scores and determine which is more effective.
+- **Monitor for quality degradation:** After modifying a critical prompt, retrieve its most recent logs to ensure that its performance hasn't declined unexpectedly.
 
-Make sure you have:
+This tutorial takes about five minutes to complete.
 
-- A PromptCrafter user account and the bearer token you received when you logged in. For help signing up or logging in, see the [Quickstart](../quickstart.md).
-- cURL or Postman.  
+## Prerequisites
 
-## Make the request
+To follow this tutorial, you need:
 
-Send a GET request to the following endpoint:
+- **Your JWT token:** All requests require a Bearer token for authentication. If you don't have a token, complete the authentication steps in the [Quickstart guide](../quickstart.md) first.
+- **At least one saved log:** You need to have logged at least one output. If you haven't, complete the [Log a generated output tutorial](test-prompt.md) first.
+- **An HTTP client:** This tutorial provides examples for both cURL and Postman.
+    - If you're using Postman, import the [PromptCrafter Postman Collection](postman.md) to follow along.
 
-```text
-https://promptcrafter-production.up.railway.app/logs
-```
+## Build the request
 
-Include the following request header:
+To view logs, send a `GET` request to the `/logs` endpoint. You can either retrieve all logs associated with your account or filter them to see only the logs for a specific prompt.
 
-- `Authorization: Bearer {your_token}`
+### Headers
 
-### Using Postman
+Add the following header to your request:
 
-1. Navigate to **Send a new API request** and click **New Request**.
-2. Set method to `GET`
-3. Set URL to:  
-   `https://promptcrafter-production.up.railway.app/logs`
-4. Click the **Authorization** tab:
-   - In the **Type** dropdown, select `Bearer Token`.
-   - In the **Token** field, enter the bearer token you received after logging in.
-5. Click **Send** to submit the request.
+- `Authorization: Bearer {your_token}` authenticates you as the user. Replace `{your_token}` with the bearer token you received after logging in.
 
-### Using cURL
+### Query parameters
+
+To retrieve logs for a single prompt, include the following optional query parameter:
+
+| Field      | Type   | Required | Description                                               |
+|------------|--------|----------|-----------------------------------------------------------|
+| `promptId` | string | No       | The unique `_id` of a prompt to filter the logs by. |
+
+If you omit the `promptId` parameter, the API returns all logs for your account.
+
+## Send the request
+
+<details>
+<summary>cURL</summary>
+
+To make the cURL commands cleaner, set shell variables for the base URL and your token. This avoids repeating them in every request.
 
 ```bash
-curl -H "Authorization: Bearer {your_token}" \
-  https://promptcrafter-production.up.railway.app/logs
+BASE_URL="https://promptcrafter-production.up.railway.app"
+TOKEN="your-jwt-goes-here" # Replace with your actual token
 ```
 
-Replace `{your_token}` with your actual bearer token.
+**To retrieve all logs:**
 
-## Check the response
+```bash
+curl -X GET $BASE_URL/logs \
+  -H "Authorization: Bearer $TOKEN"
+```
 
-If your request is successful, the server returns a status code `200 OK` and a response body like this:
+**To retrieve logs for a specific prompt:**
+
+First set a variable for the prompt's ID.
+
+```bash
+PROMPT_ID="your-prompt-id-here" # Replace with a real prompt ID
+```
+
+Now send the request with the `promptId` query parameter.
+
+```bash
+curl -X GET "$BASE_URL/logs?promptId=$PROMPT_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+</details>
+
+<details>
+<summary>Postman</summary>
+
+If you've imported the PromptCrafter Postman Collection, sending the request is simple. 
+
+- **To retrieve all logs:** In the **Logs** folder, select the **Retrieve all logs** request and click **Send**.
+- **To retrieve logs for a specific prompt:**
+    1. In the **Logs** folder, select the **Retrieve logs by prompt** request.
+    2. In the **Params** tab, replace the `{{promptId}}` variable with the ID of the prompt you want to see logs for.
+    3. Click **Send**. The collection automatically uses the `{{token}}` variable set during login, so you don't need to configure authorization headers manually.
+
+</details>
+
+## Response
+
+A successful request returns a `200 OK` status and a JSON array of log objects.
+
+If you request all logs, the response looks like this:
 
 ```json
 [
   {
-    "_id": "log3",
-    "promptId": "prompt3",
-    "output": "Ready to Upgrade? Discover the Future of Tech.",
-    "notes": "Engaging and clear subject line.",
-    "modelUsed": "Claude",
-    "score": 7,
-    "createdAt": "2024-03-03T13:00:00Z"
+    "_id": "log104",
+    "promptId": "prompt104",
+    "output": "The Industrial Revolution transformed how people lived and worked...",
+    "modelUsed": "Claude 3 Sonnet",
+    "notes": "Clear, accessible explanation for students. Good tone.",
+    "score": 8,
+    "createdAt": "2024-06-20T13:13:00Z"
   },
   {
-    "_id": "log87",
-    "promptId": "prompt34",
-    "output": "I am the ancient apple queen.",
-    "notes": "This is a William Morris line.",
-    "modelUsed": "GPT-4",
-    "score": 4,
-    "createdAt": "2025-03-03T13:14:00Z"
+    "_id": "log105",
+    "promptId": "prompt102",
+    "output": "The e-bike is fantastic! Its long battery life and smooth pedal assist make my commute a joy. I especially love the integrated lights for safety.",
+    "modelUsed": "Grok-3 Beta",
+    "notes": "Good review, meets all prompt criteria.",
+    "score": 9,
+    "createdAt": "2024-06-20T14:25:00Z"
   }
 ]
 ```
 
-Each object in the array is a log entry. The `promptId` field shows which prompt the log links to.
+If you filter by `promptId`, the array contains only logs matching that ID. If there's no log for that prompt, the API returns an empty array `[]`.
 
 ## What to do if the request doesn't work
 
-Here are error codes you might encounter, what each means, and what you can do to fix them.
+Here are issues you might encounter when retrieving logs and how to resolve them.
 
-| Status | Example response body | Meaning | How to fix |
-|--------|----------------------|---------|------------|
-| **400 Bad Request** | `{ "message": "Invalid query parameter" }` | The query string is malformed or contains unsupported parameters. | Use `/logs` to fetch all logs, or `/logs?promptId=<id>` with a valid prompt ID. |
-| **401 Unauthorized** | `{ "message": "Invalid or missing bearer token" }` | Authentication failed. | Add `Authorization: Bearer {your_token}` and confirm the token hasn’t expired. |
-| **403 Forbidden** | `{ "message": "You do not own this prompt" }` | You authenticated, but the prompt specified by `promptId` belongs to another account. | Request logs only for prompts you own, or switch to an account that owns the prompt. |
-| **404 Not Found** | `{ "message": "Prompt not found" }` | The server can’t find any prompt with the supplied `promptId`. | Verify the `promptId` value is correct and still exists. |
-| **500 Internal Server Error** | `{ "message": "Unexpected server error" }` | The server encountered an error while processing the request. | Retry later; if the error persists, contact support. |
+| Status | Example response | Cause | Solution |
+|--------|------------------|--------|----------|
+| **400 Bad Request** | `{"error": "`promptId` missing or malformed"}` | The `promptId` query parameter was included but had no value, or the value was invalid. | Ensure the `promptId` is a valid string. If you don't want to filter, remove the parameter entirely. |
+| **401 Unauthorized** | `{"error": "Authentication token is missing"}` | The `Authorization` header is missing. | Include `Authorization: Bearer {your_token}` in your request headers with a valid token. |
+| **401 Unauthorized** | `{"error": "Authentication token is expired or invalid"}` | The Bearer token is expired or malformed. | Log in again to obtain a new token and update your request. |
+| **403 Forbidden** | `{"error": "User is not authorized to view logs for this prompt."}` | You are filtering by a `promptId` that belongs to another user. | Verify the `promptId` is correct and belongs to a prompt you own. |
+| **404 Not Found** | `{"error": "No logs found for the specified prompt ID."}` | The prompt ID does not exist, or it exists but has no associated logs. | Double-check the `promptId`. If it is correct, create a log for it first. |
+| **500 Internal Server Error** | `{"error": "An unexpected server error occurred"}` | An error occurred on the server. | Retry the request after a short wait. If the error persists, contact support. |
 
 ## Next steps
 
-Learn how to [log a generated output](tutorials/test-prompt.md) or [save a prompt](tutorials/create-prompt.md).
+Now that you can review your test history, use that data to improve your prompts.
 
-## Related
-
-[Log](reference/resources/log.md)  
-[Retrieve all logs](reference/endpoints/get-logs.md): `GET /logs`  
-[Retrieve logs for a specific prompt](reference/endpoints/get-logs-by-prompt.md) `GET /logs?promptId=`  
-[Log a generated output](reference/endpoints/post-logs.md): `POST /logs`  
-[Delete a log](reference/endpoints/delete-logs-id.md): `DELETE /logs`  
+- Learn how to [Update a prompt](tutorials/update-prompt.md) based on insights from your logs.
+- Use the [Search prompts tutorial](tutorials/search-prompts.md) to find related prompts to test.
+- For complete details on parameters and endpoints, see the [log resource](reference/resources/log.md) and the [`GET /logs`](reference/endpoints/get-logs.md) endpoint documentation.


### PR DESCRIPTION
Overhauled the API tutorials to improve developer experience, clarity, and consistency, making them stronger portfolio samples. Added a new tutorial for updating prompts and significantly improved the four existing ones to adhere to the Diataxis framework and increase developer empathy.

Enhancements:
- A tutorial for the `PATCH /prompts/{promptId}` endpoint.
- Each tutorial now opens with concrete examples (e.g., refining a chatbot, A/B testing copy) to illustrate practical applications and demonstrate developer empathy.
- cURL examples now feature instructions for setting shell variables for the base URL and token, simplifying command-line usage and reducing repetition.