### PR TITLE
docs: add About page with project overview and key features

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,50 @@
+# About PromptCrafter API
+
+PromptCrafter API is a backend REST API for storing, organizing, and evaluating generative AI prompts. It's designed for developers, prompt engineers, and anyone working with generative AI who needs to maintain a structured library of prompts, track changes and performance, and integrate prompt data into external tools and apps.
+
+While the live API server is currently offline, this documentation site presents API documentation, developer reference, and SDK tooling for a fully functional API. The project demonstrates industry best practices in API reference, developer onboarding, and technical communication.
+
+## Who is PromptCrafter for?
+
+- **Developers** building or integrating generative AI solutions.
+- **Prompt engineers** iterating on and optimizing prompts for various models.
+- **Researchers** tracking prompt performance across different AI models.
+- Anyone who needs a robust, organized prompt management workflow.
+
+## What does PromptCrafter provide?
+
+- **Prompt library management:** Store, organize, and update prompts with titles, content, tags, and associated models.
+- **Output logging and scoring:** Log the outputs generated from prompts, add notes, score their effectiveness, and compare performance across models and revisions.
+- **Search:** Find prompts using full-text search across titles, content, and tags.
+- **Authentication:** Secure user access and resource ownership via JWT authentication.
+
+## Documentation and tooling
+
+This site includes:
+
+- **Comprehensive API reference:** Endpoint documentation, parameters, error handling, and usage examples.
+- **Resource schemas:** Detailed breakdowns of prompt and log objects, including all required and optional fields.
+- **Step-by-step guides and tutorials:** Clear instructions for common tasks like signing in, creating prompts, logging outputs, and searching the user's prompt library.
+- **Postman Collection:** Ready-to-import for exploring endpoints interactively, with example requests and responses.
+- **OpenAPI (Swagger) specification:** Machine-readable schema for code generation and integration.
+- **SDK documentation:** Usage samples for Python, JavaScript, Go, Java, and Ruby.
+- **Realistic, production-quality examples:** Request/response payloads that reflect real-world use.
+
+## Project Background
+
+PromptCrafter API was originally developed as a capstone project for the University of Washington Specialization in API Documentation. The project uses the same tools, workflows, and developer-focused approach found in professional API documentation environments.
+
+The API, documentation, and supporting tools were all developed to demonstrate best practices for clear, useful, and maintainable developer documentation.
+
+## Links and Resources
+
+- [Live documentation site](https://Marmelodov.github.io/PromptCrafter-API/)
+- [GitHub repository](https://github.com/Marmelodov/PromptCrafter-API)
+- [OpenAPI Specification](https://github.com/Marmelodov/PromptCrafter-API/blob/main/openapi/openapi.yaml)
+- [Postman Collection](https://github.com/Marmelodov/PromptCrafter-API/blob/main/postman/PromptCrafter.postman_collection.json)
+
+## Author and Contact
+
+**Author:** Robert Norrell  
+**LinkedIn:** [linkedin.com/in/robert-norrell-268b249b](https://linkedin.com/in/robert-norrell-268b249b)  
+**Email:** robertjnorrell@gmail.com

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,6 +1,6 @@
 # Contact
 
-For questions, bug reports, or feature requests related to the PromptCrafter API documentation, please contact:
+For questions about the PromptCrafter API documentation, please contact:
 
-**Jay Norrell**  
+**Robert Norrell**  
 [robertjnorrell@gmail.com](mailto:robertjnorrell@gmail.com)


### PR DESCRIPTION
Add about.md describing the PromptCrafter API project. Includes high-level overview, intended audience, main features, available documentation and tooling, project background, resource links, and author contact information.